### PR TITLE
Avoid memory leak in String.cString()

### DIFF
--- a/Source/LclJSONSerialization.swift
+++ b/Source/LclJSONSerialization.swift
@@ -115,7 +115,13 @@ public class LclJSONSerialization {
         }
         
         let count = jsonStr.lengthOfBytes(using: .utf8)
-	let result = Data(bytes: UnsafeRawPointer(jsonStr.cString(using: .utf8)!).bindMemory(to: UInt8.self, capacity: count), count: count)
+        let bufferLength = count+1 // Allow space for null terminator
+        var utf8: [CChar] = Array<CChar>(repeating: 0, count: bufferLength)
+        if !jsonStr.getCString(&utf8, maxLength: bufferLength, encoding: .utf8) {
+            // throw something?
+        }
+        let rawBytes = UnsafeRawPointer(UnsafePointer(utf8))
+        let result = Data(bytes: rawBytes.bindMemory(to: UInt8.self, capacity: count), count: count)
         return result
     }
     open class func data(withJSONObject value: Any, options opt: JSONSerialization.WritingOptions = []) throws -> Data {


### PR DESCRIPTION
The function [String.cString(using: Encoding)](https://github.com/apple/swift/blob/07b196d2f9a5facc490b35e3649e18937796239b/stdlib/public/SDK/Foundation/NSStringAPI.swift#L417) appears to be the cause of a memory leak with the changes in issue_788.

It would appear that the storage allocated by this function is never freed.  It looks like there is some code there which deliberately extends the lifetime of the storage there (but I don't understand the code or the motivation).

I tried replacing this with some code replicating what we do in [RouterResponse](https://github.com/IBM-Swift/Kitura/blob/master/Sources/Kitura/RouterResponse.swift#L150).  This doesn't leak and performs similar.
