### PR TITLE
Re-enable code coverage for SwiftyJSON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       sudo: required
 
 before_install:
-  - git clone https://github.com/shmuelk/Package-Builder.git
+  - git clone https://github.com/IBM-Swift/Package-Builder.git
 
 script:
   - ./Package-Builder/build-package.sh -projectDir $TRAVIS_BUILD_DIR

--- a/Tests/SwiftyJSONTests/BaseTests.swift
+++ b/Tests/SwiftyJSONTests/BaseTests.swift
@@ -52,17 +52,10 @@ class BaseTests: XCTestCase {
 
         super.setUp()
         
-        let sourceFileName = NSString(string: #file)
-        let resourceFilePrefixRange: NSRange
-        let lastSlash = sourceFileName.range(of: "/", options: .backwards)
-        if  lastSlash.location != NSNotFound {
-            resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
-        } else {
-            resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
-        }
-        let pathPrefix = sourceFileName.substring(with: resourceFilePrefixRange)
+        var testDataURL = URL(fileURLWithPath: #file)
+        testDataURL.appendPathComponent("../Tests.json")
         do {
-            self.testData = try Data(contentsOf: URL(fileURLWithPath: "\(pathPrefix)Tests.json"))
+            self.testData = try Data(contentsOf: testDataURL.standardized)
         }
         catch {
             XCTFail("Failed to read in the test data")

--- a/Tests/SwiftyJSONTests/BaseTests.swift
+++ b/Tests/SwiftyJSONTests/BaseTests.swift
@@ -51,11 +51,21 @@ class BaseTests: XCTestCase {
     override func setUp() {
 
         super.setUp()
+        
+        let sourceFileName = NSString(string: #file)
+        let resourceFilePrefixRange: NSRange
+        let lastSlash = sourceFileName.range(of: "/", options: .backwards)
+        if  lastSlash.location != NSNotFound {
+            resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
+        } else {
+            resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
+        }
+        let pathPrefix = sourceFileName.substring(with: resourceFilePrefixRange)
         do {
-            self.testData = try Data(contentsOf: URL(fileURLWithPath: "Tests/SwiftyJSONTests/Tests.json"))
+            self.testData = try Data(contentsOf: URL(fileURLWithPath: "\(pathPrefix)Tests.json"))
         }
         catch {
-            XCTFail("FAiled to read in the test data")
+            XCTFail("Failed to read in the test data")
             exit(1)
         }
     }

--- a/Tests/SwiftyJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftyJSONTests/PerformanceTests.swift
@@ -52,17 +52,10 @@ class PerformanceTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let sourceFileName = NSString(string: #file)
-        let resourceFilePrefixRange: NSRange
-        let lastSlash = sourceFileName.range(of: "/", options: .backwards)
-        if  lastSlash.location != NSNotFound {
-            resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
-        } else {
-            resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
-        }
-        let pathPrefix = sourceFileName.substring(with: resourceFilePrefixRange)
+        var testDataURL = URL(fileURLWithPath: #file)
+        testDataURL.appendPathComponent("../Tests.json")
         do {
-            self.testData = try Data(contentsOf: URL(fileURLWithPath: "\(pathPrefix)Tests.json"))
+            self.testData = try Data(contentsOf: testDataURL.standardized)
         }
         catch {
             XCTFail("Failed to read in the test data")

--- a/Tests/SwiftyJSONTests/PerformanceTests.swift
+++ b/Tests/SwiftyJSONTests/PerformanceTests.swift
@@ -52,8 +52,17 @@ class PerformanceTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        let sourceFileName = NSString(string: #file)
+        let resourceFilePrefixRange: NSRange
+        let lastSlash = sourceFileName.range(of: "/", options: .backwards)
+        if  lastSlash.location != NSNotFound {
+            resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
+        } else {
+            resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
+        }
+        let pathPrefix = sourceFileName.substring(with: resourceFilePrefixRange)
         do {
-            self.testData = try Data(contentsOf: URL(fileURLWithPath: "Tests/SwiftyJSONTests/Tests.json"))
+            self.testData = try Data(contentsOf: URL(fileURLWithPath: "\(pathPrefix)Tests.json"))
         }
         catch {
             XCTFail("Failed to read in the test data")

--- a/Tests/SwiftyJSONTests/SequenceTypeTests.swift
+++ b/Tests/SwiftyJSONTests/SequenceTypeTests.swift
@@ -47,7 +47,16 @@ class SequenceTypeTests: XCTestCase {
 // END OF GENERATED CODE
     func testJSONFile() {
         do {
-            let testData = try Data(contentsOf: URL(fileURLWithPath: "Tests/SwiftyJSONTests/Tests.json"))
+            let sourceFileName = NSString(string: #file)
+            let resourceFilePrefixRange: NSRange
+            let lastSlash = sourceFileName.range(of: "/", options: .backwards)
+            if  lastSlash.location != NSNotFound {
+                resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
+            } else {
+                resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
+            }
+            let pathPrefix = sourceFileName.substring(with: resourceFilePrefixRange)
+            let testData = try Data(contentsOf: URL(fileURLWithPath: "\(pathPrefix)Tests.json"))
             let json = JSON(data:testData)
             var ind = 0
             for (_, sub) in json {

--- a/Tests/SwiftyJSONTests/SequenceTypeTests.swift
+++ b/Tests/SwiftyJSONTests/SequenceTypeTests.swift
@@ -47,16 +47,9 @@ class SequenceTypeTests: XCTestCase {
 // END OF GENERATED CODE
     func testJSONFile() {
         do {
-            let sourceFileName = NSString(string: #file)
-            let resourceFilePrefixRange: NSRange
-            let lastSlash = sourceFileName.range(of: "/", options: .backwards)
-            if  lastSlash.location != NSNotFound {
-                resourceFilePrefixRange = NSMakeRange(0, lastSlash.location+1)
-            } else {
-                resourceFilePrefixRange = NSMakeRange(0, sourceFileName.length)
-            }
-            let pathPrefix = sourceFileName.substring(with: resourceFilePrefixRange)
-            let testData = try Data(contentsOf: URL(fileURLWithPath: "\(pathPrefix)Tests.json"))
+            var testDataURL = URL(fileURLWithPath: #file)
+            testDataURL.appendPathComponent("../Tests.json")
+            let testData = try Data(contentsOf: testDataURL.standardized)
             let json = JSON(data:testData)
             var ind = 0
             for (_, sub) in json {


### PR DESCRIPTION
Various SwiftyJSON tests read in a test JSON file for use as test data. They currently read them in, in a way that is relative to the repository. That is fine for swift test. However for XCode, they need to read in. in a way that is relative to the source files of the tests.

This PR does that.