### PR TITLE
Removed _incremental protocol from JSONIndex struct

### DIFF
--- a/Sources/SwiftyJSON/SwiftyJSON.swift
+++ b/Sources/SwiftyJSON/SwiftyJSON.swift
@@ -408,7 +408,7 @@ extension JSON : Collection, Sequence {
     }
 }
 
-public struct JSONIndex: _Incrementable, Equatable, Comparable {
+public struct JSONIndex: Equatable, Comparable {
     let arrayIndex: Array<Any>.Index?
     let dictionaryIndex: DictionaryIndex<String, Any>?
     let type: Type


### PR DESCRIPTION
Removed reference to _incremental protocol which was only used in the JSONIndex struct. It compiles and the tests pass with it removed, but Swift 4.1 removes access to it and wouldn't compile with it.